### PR TITLE
Test with Java 21 and modernization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
+  target-branch: master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+/*
+ See the documentation for more options:
+
+https://github.com/jenkins-infra/pipeline-library/
+
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>0.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
     </properties>
     <name>Pipeline restFul API Plugin</name>
 
@@ -23,6 +23,13 @@
         </license>
     </licenses>
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2179.v0884e842b_859</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
@@ -90,7 +97,7 @@
 
     <url>https://github.com/jenkinsci/pipeline-restful-api-plugin</url>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>pipeline-restful-api-0.4</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,8 +12,7 @@
     <version>0.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.164.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
     <name>Pipeline restFul API Plugin</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,44 +31,9 @@
             <scope>import</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.19</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.19</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <version>2.39</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.11.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.13</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>2.30</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>3.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/HttpFlowDefinition.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/HttpFlowDefinition.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.net.URL;
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class HttpFlowDefinition extends FlowDefinition {
         try(InputStream input = new URL(url).openStream()) {
             ByteArrayOutputStream data = new ByteArrayOutputStream();
             IOUtils.copy(input, data);
-            script = data.toString();
+            script = data.toString(StandardCharsets.UTF_8);
         }
         return new CpsFlowExecution(this.script, this.sandbox, owner);
     }

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
@@ -164,7 +164,7 @@ public class InstanceAPI implements RootAction {
         urlCon.setFixedLengthStreamingMode(jsonObj.toString().length());
 
         try(OutputStream os = urlCon.getOutputStream()) {
-            os.write(jsonObj.toString().getBytes());
+            os.write(jsonObj.toString().getBytes(StandardCharsets.UTF_8));
         }
 
         String result = "All set, jcli is ready! For example: 'jcli plugin list'. You can close this page now.";

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
@@ -179,9 +179,6 @@ public class InstanceAPI implements RootAction {
         }
 
         JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
-        if (config == null) {
-            return HttpResponses.errorJSON("cannot set Jenkins location due to it is undefined");
-        }
 
         if (StringUtils.isNotBlank(rootURL)) {
             config.setUrl(rootURL);

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/InstanceAPI.java
@@ -25,6 +25,7 @@ import javax.servlet.WriteListener;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
@@ -158,7 +159,7 @@ public class InstanceAPI implements RootAction {
         urlCon.setDoOutput(true);
 
         urlCon.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
-        JSONObject jsonObj = JSONObject.fromObject(output.toString());
+        JSONObject jsonObj = JSONObject.fromObject(output.toString(StandardCharsets.UTF_8));
         jsonObj.getJSONObject("data").put("userName", user.getFullName());
         urlCon.setFixedLengthStreamingMode(jsonObj.toString().length());
 

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/PipelineRestfulAPI.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/PipelineRestfulAPI.java
@@ -197,7 +197,7 @@ public class PipelineRestfulAPI extends AbstractWorkflowJobActionHandler {
     }
 
     @ExportedBean
-    class IdentityBuild {
+    public static class IdentityBuild {
         private WorkflowRun build;
         private IdentifyCause cause;
 

--- a/src/main/java/io/jenkins/plugins/pipeline/restful/api/PipelineRestfulAPI.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/restful/api/PipelineRestfulAPI.java
@@ -298,7 +298,7 @@ public class PipelineRestfulAPI extends AbstractWorkflowJobActionHandler {
     }
 
     @ExportedBean
-    class IdentifyCause extends Cause {
+    public static class IdentifyCause extends Cause {
         private String uuid;
         private String message;
 


### PR DESCRIPTION
Test with Java 21
==

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 after upgrading to a recent parent POM and to Jenkins version 2.387.3 as the minimum version.